### PR TITLE
feat: Make API wrapper more flexible

### DIFF
--- a/src/paspybin/api/api.py
+++ b/src/paspybin/api/api.py
@@ -1,3 +1,7 @@
+from traceback import TracebackException
+from types import TracebackType
+from typing import Self
+
 from aiohttp import ClientSession
 
 from ..types import DevKey, UserKey
@@ -30,6 +34,21 @@ class API:
         self._dev_key = dev_key
         self._user_key = user_key
         self._session = session if session is not None else ClientSession(self.base_url)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Exception,
+        exc_val: TracebackException,
+        traceback: TracebackType,
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
 
     def is_authenticated(self) -> bool:
         return self._user_key is not None

--- a/src/paspybin/api/paspybin.py
+++ b/src/paspybin/api/paspybin.py
@@ -1,9 +1,7 @@
-from traceback import TracebackException
-from types import TracebackType
-from typing import Self
+from aiohttp import ClientSession
 
 from ..exceptions import PaspybinBadAPIRequestError
-from ..types import DevKey
+from ..types import DevKey, UserKey
 from .api import API
 from .pastes import Pastes
 from .user import User
@@ -18,26 +16,16 @@ class Paspybin(API):
     Main Pastebin API class.
     """
 
-    def __init__(self, dev_key: DevKey | None = None):
-        API.__init__(self, dev_key)
+    def __init__(
+        self,
+        dev_key: DevKey | None = None,
+        user_key: UserKey | None = None,
+        session: ClientSession | None = None,
+    ):
+        API.__init__(self, dev_key, user_key, session)
 
         self.user = User(self._dev_key, self._user_key, self._session)
         self.pastes = Pastes(self._dev_key, self._user_key, self._session)
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: Exception,
-        exc_val: TracebackException,
-        traceback: TracebackType,
-    ) -> None:
-        await self.close()
-
-    async def close(self) -> None:
-        if self._session is not None:
-            await self._session.close()
 
     async def login(self, username: str, password: str) -> None:
         """

--- a/src/paspybin/api/paste.py
+++ b/src/paspybin/api/paste.py
@@ -19,14 +19,14 @@ class Paste(API, schemas.Paste):
     def __init__(
         self,
         key: PasteKey,
-        date: datetime,
-        title: str,
-        size: int,
-        expire_date: datetime,
-        private: Visibility,
-        format: Format,
-        url: PastebinUrl,
-        hits: int,
+        date: datetime | None = None,
+        title: str | None = None,
+        size: int | None = None,
+        expire_date: datetime | None = None,
+        private: Visibility | None = None,
+        format: Format | None = None,
+        url: PastebinUrl | None = None,
+        hits: int | None = None,
         dev_key: DevKey | None = None,
         user_key: UserKey | None = None,
         session: ClientSession | None = None,
@@ -42,6 +42,8 @@ class Paste(API, schemas.Paste):
 
         Raises:
             PaspybinBadAPIRequestError: if a bad request is sent to the API.
+            ValueError: if dev_key not supplied.
+            ValueError: if guest use this method.
 
         Examples:
             >>> import asyncio
@@ -58,6 +60,12 @@ class Paste(API, schemas.Paste):
             ...             pass
             >>> asyncio.run(main())
         """
+        if self._dev_key is None:
+            raise ValueError("dev_key is required to use this method")
+
+        if not self.is_authenticated():
+            raise ValueError("only logged in users can use this method")
+
         payload = {
             "api_dev_key": self._dev_key,
             "api_option": "delete",
@@ -80,6 +88,8 @@ class Paste(API, schemas.Paste):
 
         Raises:
             PaspybinBadAPIRequestError: if a bad request is sent to the API.
+            ValueError: if dev_key not supplied.
+            ValueError: if guest use this method.
 
         Examples:
             >>> import asyncio
@@ -96,6 +106,12 @@ class Paste(API, schemas.Paste):
             ...             # do what you want to do with paste content here
             >>> asyncio.run(main())
         """
+        if self._dev_key is None:
+            raise ValueError("dev_key is required to use this method")
+
+        if not self.is_authenticated():
+            raise ValueError("only logged in users can use this method")
+
         payload = {
             "api_dev_key": self._dev_key,
             "api_option": "show_paste",

--- a/src/paspybin/api/pastes.py
+++ b/src/paspybin/api/pastes.py
@@ -48,7 +48,7 @@ class Pastes(API):
             raise ValueError("dev_key is required to use this method")
 
         if not self.is_authenticated():
-            raise ValueError("only logged in users can access the paste list")
+            raise ValueError("only logged in users can use this method")
 
         payload: dict[str, Any] = {
             "api_dev_key": self._dev_key,

--- a/src/paspybin/api/user.py
+++ b/src/paspybin/api/user.py
@@ -37,7 +37,7 @@ class User(API):
             raise ValueError("dev_key is required to use this method")
 
         if not self.is_authenticated():
-            raise ValueError("only logged in users can access user details")
+            raise ValueError("only logged in users can use this method")
 
         payload = {
             "api_dev_key": self._dev_key,

--- a/src/paspybin/schemas/paste.py
+++ b/src/paspybin/schemas/paste.py
@@ -22,14 +22,20 @@ class Paste:
         format: syntax highlighting format of paste
         url: url location of paste
         hits: views count of paste
+
+    Note:
+        It is actually impossible for the fields `date`, `size`, `expire_date`,
+        `private`,`format`, `url`, and `hits` to have the value `None` based on the API
+        documentation, however, to make it easier to use the API wrapper so that it is
+        more flexible, these fields are made so that they can contain the value `None`.
     """
 
     key: PasteKey
-    date: datetime
+    date: datetime | None
     title: str | None
-    size: int
-    expire_date: datetime
-    private: Visibility
-    format: Format
-    url: PastebinUrl
-    hits: int
+    size: int | None
+    expire_date: datetime | None
+    private: Visibility | None
+    format: Format | None
+    url: PastebinUrl | None
+    hits: int | None

--- a/tests/test_api/test_paste.py
+++ b/tests/test_api/test_paste.py
@@ -112,6 +112,20 @@ async def test_paste_delete():
         )
 
 
+async def test_paste_delete_without_dev_key():
+    async with Paste() as paste:
+        with pytest.raises(ValueError, match="dev_key is required to use this method"):
+            await paste.delete()
+
+
+async def test_paste_delete_with_guest():
+    async with Paste("dev_key") as paste:
+        with pytest.raises(
+            ValueError, match="only logged in users can use this method"
+        ):
+            await paste.delete()
+
+
 async def test_paste_delete_fail():
     with patch("paspybin.api.api.ClientSession.post") as mocked:
         async with Paspybin("dev_key") as paspybin:
@@ -187,6 +201,20 @@ async def test_paste_get_content():
                 "api_user_key": "user_key",
             },
         )
+
+
+async def test_paste_get_content_without_dev_key():
+    async with Paste() as paste:
+        with pytest.raises(ValueError, match="dev_key is required to use this method"):
+            await paste.get_content()
+
+
+async def test_paste_get_content_with_guest():
+    async with Paste("dev_key") as paste:
+        with pytest.raises(
+            ValueError, match="only logged in users can use this method"
+        ):
+            await paste.get_content()
 
 
 async def test_paste_get_content_fail():

--- a/tests/test_api/test_paste.py
+++ b/tests/test_api/test_paste.py
@@ -113,13 +113,13 @@ async def test_paste_delete():
 
 
 async def test_paste_delete_without_dev_key():
-    async with Paste() as paste:
+    async with Paste("paste_key") as paste:
         with pytest.raises(ValueError, match="dev_key is required to use this method"):
             await paste.delete()
 
 
 async def test_paste_delete_with_guest():
-    async with Paste("dev_key") as paste:
+    async with Paste("paste_key", dev_key="dev_key") as paste:
         with pytest.raises(
             ValueError, match="only logged in users can use this method"
         ):
@@ -204,13 +204,13 @@ async def test_paste_get_content():
 
 
 async def test_paste_get_content_without_dev_key():
-    async with Paste() as paste:
+    async with Paste("paste_key") as paste:
         with pytest.raises(ValueError, match="dev_key is required to use this method"):
             await paste.get_content()
 
 
 async def test_paste_get_content_with_guest():
-    async with Paste("dev_key") as paste:
+    async with Paste("paste_key", dev_key="dev_key") as paste:
         with pytest.raises(
             ValueError, match="only logged in users can use this method"
         ):

--- a/tests/test_api/test_pastes.py
+++ b/tests/test_api/test_pastes.py
@@ -77,7 +77,7 @@ async def test_pastes_get_all_without_dev_key():
 async def test_pastes_get_all_with_guest():
     async with Paspybin("dev_key") as paspybin:
         with pytest.raises(
-            ValueError, match="only logged in users can access the paste list"
+            ValueError, match="only logged in users can use this method"
         ):
             async for paste in paspybin.pastes.get_all():
                 pass

--- a/tests/test_api/test_user.py
+++ b/tests/test_api/test_user.py
@@ -64,7 +64,7 @@ async def test_user_get_detail_without_dev_key():
 async def test_user_get_detail_with_guest():
     async with Paspybin("dev_key") as paspybin:
         with pytest.raises(
-            ValueError, match="only logged in users can access user details"
+            ValueError, match="only logged in users can use this method"
         ):
             await paspybin.user.get_detail()
 


### PR DESCRIPTION
Make API wrapper more flexible by allowing each of them to use `async with` style keyword independently without being tied to the main class. This PR also add more some tests and changes some exception message from API wrapper.